### PR TITLE
Eliminate extra newline from glob pattern in outputBinding.

### DIFF
--- a/cwl/vaf_length_depth_filters.cwl
+++ b/cwl/vaf_length_depth_filters.cwl
@@ -46,8 +46,7 @@ outputs:
   - id: filtered_vcf
     type: File
     outputBinding:
-      glob: |
-        results/vaf_length_depth_filters/filtered.vcf
+      glob: results/vaf_length_depth_filters/filtered.vcf
 label: vaf_length_depth_filters
 arguments:
   - position: 99


### PR DESCRIPTION
Alternatively this could've been:
```yaml
glob: |-
  results/vaf_length_depth_filters/filtered.vcf
```
since the `-` also serves to strip the final newline, but there's no need to use a multiline string here.