### PR TITLE
Tsl default pick order for vep annotate

### DIFF
--- a/cwl/vep_annotate.cwl
+++ b/cwl/vep_annotate.cwl
@@ -55,6 +55,9 @@ arguments:
   - position: 0
     prefix: '--results_dir'
     valueFrom: results
+  - position: 0
+    prefix: '--vep_opts'
+    valueFrom: "'--pick --pick_order tsl'"
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement


### PR DESCRIPTION
Added argument so cwl is compatible with new vep annotate functionality in TinDaisy-Core.

Argument sets default pick order to tsl.